### PR TITLE
dbExecutorKey now checked string key if custom type nil

### DIFF
--- a/file.go.tmpl
+++ b/file.go.tmpl
@@ -28,7 +28,11 @@ type DBExecutor interface {
 type DBExecutorKey string
 
 func fromContext(ctx context.Context) DBExecutor {
-    dbe, ok := ctx.Value(DBExecutorKey("dbExecutor")).(DBExecutor)
+    dbExecutorVal := ctx.Value(DBExecutorKey("dbExecutor"))
+    if dbExecutorVal == nil {
+        dbExecutorVal = ctx.Value("dbExecutor")
+    }
+    dbe, ok := dbExecutorVal.(DBExecutor)
     if !ok {
         panic("DBExecutor not found in context")
     }


### PR DESCRIPTION
There was a compatibility issue with Gin (where only string keys, not custom types, can be used for passing context). Now, if a custom type key is not found, it checks for the presence of a string type key.